### PR TITLE
fix: Hide empty roots from org chart

### DIFF
--- a/frontend/src/pages/OrgChart.js
+++ b/frontend/src/pages/OrgChart.js
@@ -49,7 +49,7 @@ const listToTree = list => {
       roots.push(node);
     }
   }
-  return roots;
+  return roots.filter(n => n.children.length);
 };
 
 const Node = ({ node }) => {


### PR DESCRIPTION
bors r+