### PR TITLE
feat: Update users query to return facets inline

### DIFF
--- a/backend/atlas/models/profile.py
+++ b/backend/atlas/models/profile.py
@@ -35,7 +35,10 @@ class Profile(models.Model):
         "atlas.Office", null=True, on_delete=models.SET_NULL, related_name="profiles"
     )
     department = models.ForeignKey(
-        "atlas.Department", null=True, on_delete=models.SET_NULL
+        "atlas.Department",
+        null=True,
+        on_delete=models.SET_NULL,
+        related_name="profiles",
     )
     primary_phone = models.TextField(null=True)
     linkedin = models.TextField(null=True)

--- a/backend/atlas/queries/departments.py
+++ b/backend/atlas/queries/departments.py
@@ -57,10 +57,10 @@ class Query(object):
 
         if people_only:
             qs = qs.filter(
-                profile__is_human=True,
-                profile__user__is_active=True,
-                profile__is_directory_hidden=False,
-            ).exclude(profile=None)
+                profiles__is_human=True,
+                profiles__user__is_active=True,
+                profiles__is_directory_hidden=False,
+            ).exclude(profiles=None)
 
         if cost_center is not None:
             qs = qs.filter(cost_center=cost_center)

--- a/backend/atlas/schema/department.py
+++ b/backend/atlas/schema/department.py
@@ -38,6 +38,8 @@ class DepartmentNode(gql_optimizer.OptimizedDjangoObjectType):
         return [results[i] for i in self.tree]
 
     def resolve_num_people(self, info):
+        if hasattr(self, "num_people"):
+            return self.num_people
         if not self.id:
             return 0
         qs = Profile.objects.filter(

--- a/backend/atlas/schema/employeetype.py
+++ b/backend/atlas/schema/employeetype.py
@@ -18,6 +18,8 @@ class EmployeeTypeNode(graphene.ObjectType):
     num_people = graphene.Int(required=False)
 
     def resolve_num_people(self, info):
+        if "num_people" in self:
+            return self["num_people"]
         if not self["id"]:
             return 0
         qs = Profile.objects.filter(

--- a/backend/atlas/schema/office.py
+++ b/backend/atlas/schema/office.py
@@ -32,10 +32,10 @@ class OfficeNode(gql_optimizer.OptimizedDjangoObjectType):
 
     @gql_optimizer.resolver_hints(prefetch_related=("profiles", "profiles__user"))
     def resolve_num_people(self, info):
-        if not self.id:
-            return 0
         if hasattr(self, "num_people"):
             return self.num_people
+        if not self.id:
+            return 0
         qs = self.profiles.filter(is_human=True, is_directory_hidden=False)
         if (
             not hasattr(self, "_prefetched_objects_cache")

--- a/frontend/src/components/PeopleList.js
+++ b/frontend/src/components/PeopleList.js
@@ -23,7 +23,7 @@ export default function PeopleList({ query }) {
         return (
           <React.Fragment>
             <Flex flexWrap="wrap" mx={-2}>
-              {users.map(u => (
+              {users.results.map(u => (
                 <Box px={1} mx="auto" width={196} key={u.id}>
                   <PersonCard user={u} />
                 </Box>
@@ -48,16 +48,20 @@ function loadMorePeople(users, fetchMore) {
   fetchMore({
     variables: {
       ...peopleQueryVars,
-      offset: users.length
+      offset: users.results.length
     },
     updateQuery: (previousResult, { fetchMoreResult }) => {
       if (!fetchMoreResult) {
         return previousResult;
       }
-      return Object.assign({}, previousResult, {
-        // Append the new results to the old one
-        users: [...previousResult.users, ...fetchMoreResult.users]
-      });
+      return {
+        ...fetchMoreResult,
+        users: {
+          ...fetchMoreResult.users,
+          // Append the new results to the old one
+          results: [...previousResult.users.results, ...fetchMoreResult.users.results]
+        }
+      };
     }
   });
 }

--- a/frontend/src/components/Person.js
+++ b/frontend/src/components/Person.js
@@ -163,9 +163,9 @@ class Person extends Component {
         {({ loading, error, data }) => {
           if (error) return <ErrorMessage message="Error loading person." />;
           if (loading) return <div>Loading</div>;
-          if (!data.users.length)
+          if (!data.users.results.length)
             return <ErrorMessage message="Couldn't find that person." />;
-          const thisPerson = data.users[0];
+          const thisPerson = data.users.results[0];
           const dob = thisPerson.dobMonth
             ? moment(
                 `${new Date().getFullYear()}-${thisPerson.dobMonth}-${thisPerson.dobDay}`,

--- a/frontend/src/components/PersonSelectField.js
+++ b/frontend/src/components/PersonSelectField.js
@@ -97,8 +97,8 @@ export default class PersonSelectField extends Component {
           query: inputValue
         }
       })
-      .then(({ data: { users } }) => {
-        callback(users.filter(u => !this.props.exclude || this.props.exclude !== u.id));
+      .then(({ data: { users: { results } } }) => {
+        callback(results.filter(u => !this.props.exclude || this.props.exclude !== u.id));
       });
   };
 

--- a/frontend/src/components/UpdatePersonForm.js
+++ b/frontend/src/components/UpdatePersonForm.js
@@ -42,71 +42,73 @@ export const PERSON_QUERY = gql`
       name
     }
     users(humansOnly: false, email: $email, includeHidden: true) {
-      id
-      name
-      email
-      handle
-      bio
-      pronouns
-      department {
+      results {
         id
         name
-        costCenter
-        tree {
+        email
+        handle
+        bio
+        pronouns
+        department {
+          id
           name
           costCenter
+          tree {
+            name
+            costCenter
+          }
         }
-      }
-      title
-      dateOfBirth
-      dateStarted
-      primaryPhone
-      employeeType {
-        id
-        name
-      }
-      isHuman
-      isDirectoryHidden
-      isSuperuser
-      schedule {
-        sunday
-        monday
-        tuesday
-        wednesday
-        thursday
-        friday
-        saturday
-      }
-      social {
-        linkedin
-        github
-        twitter
-      }
-      gamerTags {
-        steam
-        xbox
-        playstation
-        nintendo
-      }
-      office {
-        id
-        name
-      }
-      reportsTo {
-        id
-        name
-        email
-        photo {
-          data
-          width
-          height
-          mimeType
+        title
+        dateOfBirth
+        dateStarted
+        primaryPhone
+        employeeType {
+          id
+          name
         }
-      }
-      referredBy {
-        id
-        name
-        email
+        isHuman
+        isDirectoryHidden
+        isSuperuser
+        schedule {
+          sunday
+          monday
+          tuesday
+          wednesday
+          thursday
+          friday
+          saturday
+        }
+        social {
+          linkedin
+          github
+          twitter
+        }
+        gamerTags {
+          steam
+          xbox
+          playstation
+          nintendo
+        }
+        office {
+          id
+          name
+        }
+        reportsTo {
+          id
+          name
+          email
+          photo {
+            data
+            width
+            height
+            mimeType
+          }
+        }
+        referredBy {
+          id
+          name
+          email
+        }
       }
     }
   }
@@ -156,7 +158,7 @@ class UpdatePersonForm extends Component {
         {({ loading, data: { employeeTypes, offices, users } }) => {
           //if (error) return <ErrorMessage message="Error loading person." />;
           if (loading) return <div>Loading</div>;
-          const user = users.find(
+          const user = users.results.find(
             u => u.email.toLowerCase() === this.props.email.toLowerCase()
           );
           if (!user) return <ErrorMessage message="Couldn't find that person." />;

--- a/frontend/src/pages/AdminAudit.js
+++ b/frontend/src/pages/AdminAudit.js
@@ -24,7 +24,7 @@ export default () => (
           if (error) throw error;
           if (loading) return <PageLoader />;
           const { users } = data;
-          return users
+          return users.results
             .filter(u => {
               const employeeTypeId = u.employeeType ? u.employeeType.id : null;
               return (

--- a/frontend/src/pages/AdminBulkUpdatePeople.js
+++ b/frontend/src/pages/AdminBulkUpdatePeople.js
@@ -74,7 +74,7 @@ export default class AdminBulkUpdatePeople extends Component {
           {({ loading, error, data }) => {
             if (error) throw error;
             if (loading) return <PageLoader />;
-            const { users } = data;
+            const users = data.users.results;
             const initialValues = {
               users: {}
             };

--- a/frontend/src/pages/AdminImportExportPeople.js
+++ b/frontend/src/pages/AdminImportExportPeople.js
@@ -42,8 +42,10 @@ class ExportCard extends Component {
         query: EXPORT_PEOPLE_QUERY
       })
       .then(response => {
-        const { users } = response.data;
-        if (users) {
+        const {
+          users: { matches }
+        } = response.data;
+        if (matches) {
           downloadCsv(
             [
               [
@@ -60,7 +62,7 @@ class ExportCard extends Component {
                 "is_human",
                 "is_directory_hidden"
               ],
-              ...users.map(u => [
+              ...matches.map(u => [
                 u.id,
                 u.name,
                 u.email,

--- a/frontend/src/pages/Home.js
+++ b/frontend/src/pages/Home.js
@@ -70,7 +70,7 @@ export default class Home extends Component {
                     if (error) return <ErrorMessage message="Error loading people." />;
                     if (loading) return <PageLoader />;
                     const { users } = data;
-                    if (!users.length) {
+                    if (!users.results.length) {
                       return (
                         <p>
                           {`It looks like there's been no newly added teammates in the last
@@ -78,7 +78,7 @@ export default class Home extends Component {
                         </p>
                       );
                     }
-                    return <PersonList people={users} withStartDate />;
+                    return <PersonList people={users.results} withStartDate />;
                   }}
                 </Query>
               </Card>
@@ -101,12 +101,12 @@ export default class Home extends Component {
                     if (error) return <ErrorMessage message="Error loading people." />;
                     if (loading) return <PageLoader />;
                     const { users } = data;
-                    if (!users.length) {
+                    if (!users.results.length) {
                       return (
                         <p>{`It looks like there's no recent or upcoming birthdays.`}</p>
                       );
                     }
-                    return <PersonList people={users} withBirthday />;
+                    return <PersonList people={users.results} withBirthday />;
                   }}
                 </Query>
               </Card>
@@ -131,12 +131,12 @@ export default class Home extends Component {
                     if (error) return <ErrorMessage message="Error loading people." />;
                     if (loading) return <PageLoader />;
                     const { users } = data;
-                    if (!users.length) {
+                    if (!users.results.length) {
                       return (
                         <p>{`It looks like there's no recent or upcoming anniversaries.`}</p>
                       );
                     }
-                    return <PersonList people={users} withAnniversary />;
+                    return <PersonList people={users.results} withAnniversary />;
                   }}
                 </Query>
               </Card>

--- a/frontend/src/pages/Office.js
+++ b/frontend/src/pages/Office.js
@@ -153,7 +153,7 @@ export default class Office extends Component {
                           if (loading) return <div>Loading</div>;
                           return (
                             <Flex flexWrap="wrap" mx={-2}>
-                              {data.users.map(u => (
+                              {data.users.results.map(u => (
                                 <Box px={1} mx="auto" width={196}>
                                   <PersonCard user={u} key={u.id} />
                                 </Box>

--- a/frontend/src/queries.js
+++ b/frontend/src/queries.js
@@ -151,31 +151,33 @@ export const LIST_PEOPLE_QUERY = gql`
       offset: $offset
       limit: $limit
     ) {
-      id
-      name
-      email
-      department {
+      results {
         id
         name
-      }
-      isHuman
-      isDirectoryHidden
-      title
-      dobMonth
-      dobDay
-      dateStarted
-      photo {
-        data
-        width
-        height
-        mimeType
-      }
-      employeeType {
-        id
-        name
-      }
-      reportsTo {
-        id
+        email
+        department {
+          id
+          name
+        }
+        isHuman
+        isDirectoryHidden
+        title
+        dobMonth
+        dobDay
+        dateStarted
+        photo {
+          data
+          width
+          height
+          mimeType
+        }
+        employeeType {
+          id
+          name
+        }
+        reportsTo {
+          id
+        }
       }
     }
   }
@@ -184,112 +186,114 @@ export const LIST_PEOPLE_QUERY = gql`
 export const GET_PERSON_QUERY = gql`
   query getPerson($email: String, $includeHidden: Boolean) {
     users(email: $email, humansOnly: false, includeHidden: $includeHidden) {
-      id
-      name
-      email
-      handle
-      bio
-      department {
+      results {
         id
         name
-        tree {
+        email
+        handle
+        bio
+        department {
+          id
+          name
+          tree {
+            id
+            name
+          }
+        }
+        dobMonth
+        dobDay
+        title
+        dateStarted
+        primaryPhone
+        isHuman
+        isDirectoryHidden
+        employeeType {
           id
           name
         }
-      }
-      dobMonth
-      dobDay
-      title
-      dateStarted
-      primaryPhone
-      isHuman
-      isDirectoryHidden
-      employeeType {
-        id
-        name
-      }
-      tenurePercent
-      pronouns
-      schedule {
-        sunday
-        monday
-        tuesday
-        wednesday
-        thursday
-        friday
-        saturday
-      }
-      social {
-        linkedin
-        github
-        twitter
-      }
-      gamerTags {
-        steam
-        xbox
-        playstation
-        nintendo
-      }
-      reports {
-        id
-        name
-        email
-        title
+        tenurePercent
+        pronouns
+        schedule {
+          sunday
+          monday
+          tuesday
+          wednesday
+          thursday
+          friday
+          saturday
+        }
+        social {
+          linkedin
+          github
+          twitter
+        }
+        gamerTags {
+          steam
+          xbox
+          playstation
+          nintendo
+        }
+        reports {
+          id
+          name
+          email
+          title
+          photo {
+            data
+            width
+            height
+            mimeType
+          }
+        }
+        peers {
+          id
+          name
+          email
+          title
+          photo {
+            data
+            width
+            height
+            mimeType
+          }
+        }
         photo {
           data
           width
           height
           mimeType
         }
-      }
-      peers {
-        id
-        name
-        email
-        title
-        photo {
-          data
-          width
-          height
-          mimeType
+        office {
+          id
+          externalId
+          name
+          location
+          lat
+          lng
         }
-      }
-      photo {
-        data
-        width
-        height
-        mimeType
-      }
-      office {
-        id
-        externalId
-        name
-        location
-        lat
-        lng
-      }
-      reportsTo {
-        id
-        name
-        email
-        title
-        photo {
-          data
-          width
-          height
-          mimeType
+        reportsTo {
+          id
+          name
+          email
+          title
+          photo {
+            data
+            width
+            height
+            mimeType
+          }
         }
-      }
-      referredBy {
-        id
-        name
-        email
-        title
-        photo {
-          data
-          width
-          height
-          mimeType
+        referredBy {
+          id
+          name
+          email
+          title
+          photo {
+            data
+            width
+            height
+            mimeType
+          }
         }
       }
     }
@@ -299,15 +303,17 @@ export const GET_PERSON_QUERY = gql`
 export const SELECT_PEOPLE_QUERY = gql`
   query listPeopleForSelect($query: String!, $includeHidden: Boolean) {
     users(humansOnly: true, query: $query, limit: 10, includeHidden: $includeHidden) {
-      id
-      name
-      email
-      title
-      photo {
-        data
-        width
-        height
-        mimeType
+      results {
+        id
+        name
+        email
+        title
+        photo {
+          data
+          width
+          height
+          mimeType
+        }
       }
     }
   }
@@ -316,26 +322,28 @@ export const SELECT_PEOPLE_QUERY = gql`
 export const EXPORT_PEOPLE_QUERY = gql`
   query exportPeople {
     users(limit: 1000, includeHidden: true) {
-      id
-      name
-      email
-      department {
+      results {
         id
         name
-        costCenter
-      }
-      office {
-        externalId
-      }
-      employeeType {
-        id
-      }
-      isHuman
-      isDirectoryHidden
-      title
-      dateStarted
-      reportsTo {
         email
+        department {
+          id
+          name
+          costCenter
+        }
+        office {
+          externalId
+        }
+        employeeType {
+          id
+        }
+        isHuman
+        isDirectoryHidden
+        title
+        dateStarted
+        reportsTo {
+          email
+        }
       }
     }
   }


### PR DESCRIPTION
This allows a future update to the people search to update facet maps to have accurate counts based on the whole of the user filter, vs implementing complex filters on every query endpoint.

bors r+