### PR TITLE
feat: Improve change versions for onboarding

### DIFF
--- a/backend/atlas/management/commands/sync_google.py
+++ b/backend/atlas/management/commands/sync_google.py
@@ -10,6 +10,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--domain", type=str, default=settings.GOOGLE_DOMAIN)
         parser.add_argument("--push", action="store_true", default=False)
+        parser.add_argument("--ignore-versions", action="store_true", default=False)
         parser.add_argument("users", nargs="*", metavar="EMAIL")
 
     def handle(self, *args, **options):
@@ -30,7 +31,10 @@ class Command(BaseCommand):
             )
         else:
             result = google.sync_domain(
-                identity=identity, domain=domain, users=options["users"]
+                identity=identity,
+                domain=domain,
+                users=options["users"],
+                ignore_versions=options["ignore_versions"],
             )
         self.stdout.write(self.style.MIGRATE_HEADING("Done!"))
 

--- a/backend/atlas/middleware/auth.py
+++ b/backend/atlas/middleware/auth.py
@@ -20,11 +20,11 @@ def get_user(header):
     try:
         user = User.objects.get(id=payload["uid"])
     except (TypeError, KeyError, User.DoesNotExist):
-        logging.error("auth.invalid-uid")
+        logging.error("auth.invalid-uid", exc_info=True)
         return AnonymousUser()
 
     if security_hash(user) != payload["sh"]:
-        logging.error("auth.invalid-security-hash")
+        logging.error("auth.invalid-security-hash uid={}".format(payload["uid"]))
         return AnonymousUser()
 
     return user

--- a/backend/atlas/mutations/test_login.py
+++ b/backend/atlas/mutations/test_login.py
@@ -109,6 +109,8 @@ def test_login_new_user_google_auth(gql_client, responses):
     user = User.objects.get(id=resp["user"]["id"])
     assert user.name == "Jane Smith"
     assert user.email == "jsmith@example.com"
+    profile = user.profile
+    assert profile.title == "CTO"
 
     assert isinstance(resp["token"], str)
 

--- a/backend/atlas/utils/auth.py
+++ b/backend/atlas/utils/auth.py
@@ -22,13 +22,13 @@ def parse_token(token: str) -> Optional[str]:
     try:
         payload = s.loads(token)
     except BadSignature:
-        logger.warning("auth: bad signature")
+        logger.warning("auth.bad-signature")
         return None
     if "uid" not in payload:
-        logger.warning("auth: missing uid")
+        logger.warning("auth.missing-uid")
         return None
     if "sh" not in payload:
-        logger.warning("auth: missing security hash")
+        logger.warning("auth.missing-security-hash")
         return None
     return payload
 

--- a/backend/atlas/utils/test_google.py
+++ b/backend/atlas/utils/test_google.py
@@ -538,6 +538,23 @@ def test_sync_user_refuses_old_version_update(responses, default_user, user_payl
     assert user.name != "Joe Doe"
 
 
+def test_sync_user_updates_old_version_update_with_ignore_versions(
+    responses, default_user, user_payload
+):
+    last_change = Change.record(default_user, {})
+
+    user_payload["customSchemas"]["System"]["Version"] = last_change.version - 1
+
+    user_payload["name"] = {"fullName": "Joe Doe"}
+    result = sync_user(data=user_payload, ignore_versions=True)
+    assert not result.created
+    assert result.updated
+
+    user = result.user
+    assert user.id == default_user.id
+    assert user.name == "Joe Doe"
+
+
 def test_sync_user_accepts_same_version_update(responses, default_user, user_payload):
     last_change = Change.record(default_user, {})
 


### PR DESCRIPTION
- Add --ignore-versions to sync_google
- Treat the initial version (written during onboarding, potentially) as version 0