### PR TITLE
fix(cd): pipeline group must be atlas

### DIFF
--- a/gocd/pipelines/atlas.yaml
+++ b/gocd/pipelines/atlas.yaml
@@ -3,7 +3,7 @@
 # - https://www.notion.so/sentry/GoCD-New-Service-Quickstart-6d8db7a6964049b3b0e78b8a4b52e25d
 format_version: 10
 pipelines:
-    atlas:
+    deploy-atlas:
         environment_variables:
             GCP_PROJECT: internal-sentry
             GKE_CLUSTER: zdpwkxst

--- a/gocd/pipelines/atlas.yaml
+++ b/gocd/pipelines/atlas.yaml
@@ -10,7 +10,7 @@ pipelines:
             GKE_REGION: us-central1
             GKE_CLUSTER_ZONE: b
             GKE_BASTION_ZONE: b
-        group: internal-sentry
+        group: atlas
         lock_behavior: unlockWhenFinished
         materials:
             atlas_repo:


### PR DESCRIPTION
```
I. Rule Validation Errors: 
	1. Not allowed to refer to pipeline group 'internal-sentry'. Check the 'Rules' of this config repository.;; 
```